### PR TITLE
[UPDATE] Alterada a nomenclatura do card Conselho de cultura -> "List…

### DIFF
--- a/webapp/src/core/components/AppDrawer.vue
+++ b/webapp/src/core/components/AppDrawer.vue
@@ -169,7 +169,7 @@ export default {
           name: 'inscricao-lista-parcial-route',
         },
         {
-          title: 'Lista parcial dos habilitados',
+          title: 'Lista final dos habilitados',
           group: 'apps',
           icon: 'list',
           name: 'inscricao-lista-parcial-habilitacao-route',

--- a/webapp/src/modules/site/router.js
+++ b/webapp/src/modules/site/router.js
@@ -34,10 +34,10 @@ export default [
         component: () => import(/* webpackChunkName: "site-inscricao-lista-parcial" */ '@/modules/site/views/inscricao/ListaParcial.vue'),
       },
       {
-        path: 'inscricao/lista-parcial-habilitados',
+        path: 'inscricao/lista-final-habilitados',
         name: 'inscricao-lista-parcial-habilitacao-route',
         meta: {
-          title: 'Lista parcial dos habilitados',
+          title: 'Lista final dos habilitados',
           group: 'apps',
           icon: 'dashboard',
           public: true,

--- a/webapp/src/modules/site/views/Inicio.vue
+++ b/webapp/src/modules/site/views/Inicio.vue
@@ -85,7 +85,7 @@
                   </v-card-title>
                   <v-card-text>
                     <div class="text-xs-center">
-                      Lista parcial de habilitação
+                      Lista final de habilitação
                     </div>
                     <div style="margin-top: 49px" class="subheading text-xs-center">
                       Consulte aqui
@@ -95,7 +95,7 @@
                     <v-btn
                       style="margin-top: 10px"
                       color="green darken-4"
-                      to="/inscricao/lista-parcial-habilitados"
+                      to="/inscricao/lista-final-habilitados"
                       dark
                     >
                       <v-icon>

--- a/webapp/src/modules/site/views/inscricao/ListaParcialHabilitacao.vue
+++ b/webapp/src/modules/site/views/inscricao/ListaParcialHabilitacao.vue
@@ -128,7 +128,7 @@ export default {
           value: 'endereco.municipio.uf.regiao.no_regiao',
         },
         {
-          text: 'Resultado parcial da habilitação',
+          text: 'Resultado final da habilitação',
           value: 'conselhoHabilitacao.ds_avaliacao',
         },
       ],


### PR DESCRIPTION
…a parcial de habilitação" PARA "Lista final de habilitação".

[UPDATE] Alterado o nome do menu lateral "Lista parcial dos habilitados" para "Lista final dos habilitados".
[UPDATE] Alterada a nomenclatura "parcial" para "final" na tela com a lista dos conselhos habilitados (título e nome da coluna).
[UPDATE] Alterar a rota de acesso de "/inscricao/lista-parcial-habilitados" para "/inscricao/lista-final-habilitados"