### PR TITLE
Feature/mensagens com callback

### DIFF
--- a/webapp/src/App.vue
+++ b/webapp/src/App.vue
@@ -71,16 +71,16 @@ export default {
   created() {
     const self = this;
     eventHub.$on('eventoErro', (payload) => {
-      self.notificarErro(payload);
+      self.setMensagemErro({ text: payload });
     });
     eventHub.$on('eventoSucesso', (payload) => {
-      self.notificarSucesso(payload);
+      self.setMensagemSucesso({ text: payload });
     });
   },
   methods: {
     ...mapActions({
-      notificarErro: 'app/setMensagemErro',
-      notificarSucesso: 'app/setMensagemSucesso',
+      setMensagemErro: 'app/setMensagemErro',
+      setMensagemSucesso: 'app/setMensagemSucesso',
     }),
     openThemeSettings() {
       this.$vuetify.goTo(0);

--- a/webapp/src/core/store/app/index.js
+++ b/webapp/src/core/store/app/index.js
@@ -17,48 +17,53 @@ const getters = {
   mode: state => state.mode,
 };
 
+const definirMensagem = ({ commit, state }, text, { color, callbackAfterHide }) => {
+  commit('definirSnackBar', {
+    show: true,
+    color,
+    text,
+  });
+
+  setTimeout(() => {
+    commit('definirSnackBar', {
+      show: false,
+    });
+    if (callbackAfterHide) {
+      callbackAfterHide.call(this);
+    }
+  }, state.snackbar.timeout, state);
+};
+
 const actions = {
-  setSnackbar({ commit }, params) {
-    commit('setSnackBar', params);
-
-    setTimeout(() => {
-      commit('setSnackBar', {
-        show: false,
-      });
-    }, state.snackbar.timeout, state);
+  setMensagemErro({ commit, state }, { text, callbackAfterHide }) {
+    definirMensagem(
+      { commit, state },
+      {
+        text,
+        color: 'error',
+        callbackAfterHide,
+      },
+    );
   },
-  setMensagemErro({ commit, state }, message) {
-    commit('setSnackBar', {
-      show: true,
-      color: 'error',
-      text: message,
-    });
-
-    setTimeout(() => {
-      commit('setSnackBar', {
-        show: false,
-      });
-    }, state.snackbar.timeout, state);
+  setMensagemSucesso({ commit, state }, { text, callbackAfterHide }) {
+    definirMensagem(
+      { commit, state },
+      {
+        text,
+        color: 'success',
+        callbackAfterHide,
+      },
+    );
   },
-  setMensagemSucesso({ commit }, message) {
-    commit('setSnackBar', {
-      show: true,
-      color: 'success',
-      text: message,
-    });
-
-    setTimeout(() => {
-      commit('setSnackBar', {
-        show: false,
-      });
-    }, state.snackbar.timeout, state);
-  },
-  setMensagemInfo({ commit }, message) {
-    commit('setSnackBar', {
-      show: true,
-      color: 'info',
-      text: message,
-    });
+  setMensagemInfo({ commit, state }, { text, callbackAfterHide }) {
+    definirMensagem(
+      { commit, state },
+      {
+        text,
+        color: 'info',
+        callbackAfterHide,
+      },
+    );
   },
 };
 
@@ -66,7 +71,7 @@ const mutations = {
   setThemeColor(state, payload) {
     state.themeColor = payload;
   },
-  setSnackBar(state, payload) {
+  definirSnackBar(state, payload) {
     state.snackbar = Object.assign({}, state.snackbar, payload);
   },
 };

--- a/webapp/src/core/store/app/index.js
+++ b/webapp/src/core/store/app/index.js
@@ -17,7 +17,7 @@ const getters = {
   mode: state => state.mode,
 };
 
-const definirMensagem = ({ commit, state }, text, { color, callbackAfterHide }) => {
+const definirMensagem = ({ commit, state }, { text, color, callbackAfterHide }) => {
   commit('definirSnackBar', {
     show: true,
     color,

--- a/webapp/src/modules/conselho/store/actions.js
+++ b/webapp/src/modules/conselho/store/actions.js
@@ -28,7 +28,7 @@ export const obterDadosConselho = async ({ commit, dispatch }, coConselho) => {
     .catch((error) => {
       dispatch(
         'app/setMensagemErro',
-        error.response.data.error,
+        { text: error.response.data.error },
         { root: true },
       );
       throw new TypeError(error, 'obterDadosConselho', 10);
@@ -47,7 +47,7 @@ export const obterDadosRecurso = async ({ commit, dispatch }, coConselho) => con
   .catch((error) => {
     dispatch(
       'app/setMensagemErro',
-      error.response.data.error,
+      { text: error.response.data.error },
       { root: true },
     );
     throw new TypeError(error, 'obterDadosRecurso', 10);
@@ -70,7 +70,7 @@ export const obterConselhosHabilitacao = async ({ commit }) => {
 export const avaliarHabilitacao = async ({ dispatch }, conselhoHabilitacao) => conselhoService.avaliarHabilitacao(conselhoHabilitacao).then(response => response).catch((error) => {
   dispatch(
     'app/setMensagemErro',
-    error.response.data.message,
+    { text: error.response.data.message },
     { root: true },
   );
   throw new TypeError(error);
@@ -98,9 +98,9 @@ export const enviarIndicacaoConselho = async ({ dispatch }, payload) => conselho
   return response;
 }).catch((error) => {
   dispatch(
-      'app/setMensagemErro',
-      error.response.data.message,
-      { root: true },
+    'app/setMensagemErro',
+    { text: error.response.data.message },
+    { root: true },
   );
   throw new TypeError(error);
 });
@@ -109,9 +109,9 @@ export const enviarIndicacaoConselhoArquivo = async ({ dispatch }, payload) => c
   .then(response => response)
   .catch((error) => {
     dispatch(
-        'app/setMensagemErro',
-        error.response.data.message,
-        { root: true },
+      'app/setMensagemErro',
+      { text: error.response.data.message },
+      { root: true },
     );
     throw new TypeError(error);
   });
@@ -122,7 +122,7 @@ export const obterListaIndicacaoConselho = async ({ commit, dispatch }, payload)
 }).catch((error) => {
   dispatch(
     'app/setMensagemErro',
-    error.response.data.message,
+    { text: error.response.data.message },
     { root: true },
   );
   throw new TypeError(error);
@@ -132,14 +132,14 @@ export const deletarIndicacaoConselho = async ({ commit, dispatch }, coConselhoI
   commit(types.DELETAR_INDICACAO_CONSELHO, coConselhoIndicacao);
   dispatch(
     'app/setMensagemSucesso',
-    'Indicado excluído com sucesso.',
+    { text: 'Indicado excluído com sucesso.' },
     { root: true },
   );
   return response;
 }).catch((error) => {
   dispatch(
     'app/setMensagemErro',
-    error.response.data.message,
+    { text: error.response.data.message },
     { root: true },
   );
   throw new TypeError(error);
@@ -152,14 +152,14 @@ export const concluirIndicacao = async ({ commit, dispatch }, conselhoId) => con
   commit(types.CONCLUIR_INDICACAO);
   dispatch(
     'app/setMensagemSucesso',
-    'Indicação concluída com sucesso.',
+    { text: 'Indicação concluída com sucesso.'},
     { root: true },
   );
   return response;
 }).catch((error) => {
   dispatch(
     'app/setMensagemErro',
-    error.response.data.message,
+    { text: error.response.data.message },
     { root: true },
   );
   throw new TypeError(error);

--- a/webapp/src/modules/conselho/views/Conselho.vue
+++ b/webapp/src/modules/conselho/views/Conselho.vue
@@ -673,7 +673,7 @@ export default {
       const faseOrganizacao = data.find(fase => fase.tp_fase === faseSlug);
 
       if ((!faseOrganizacao || Object.keys(faseOrganizacao).length === 0) && self.perfil.no_perfil !== 'administrador') {
-        self.mensagemErro('O prazo de inscrições expirou!');
+        self.setMensagemErro({ text: 'O prazo de inscrições expirou!'});
         self.$router.push('/');
       }
       self.dataDentroPrazoInscricao = true;
@@ -694,7 +694,7 @@ export default {
   },
   methods: {
     ...mapActions({
-      mensagemErro: 'app/setMensagemErro',
+      setMensagemErro: 'app/setMensagemErro',
       obterEstados: 'localidade/obterEstados',
       obterMunicipios: 'localidade/obterMunicipios',
       confirmarConselho: 'conselho/confirmarConselho',

--- a/webapp/src/modules/conselho/views/ConselhoHabilitacaoRecurso.vue
+++ b/webapp/src/modules/conselho/views/ConselhoHabilitacaoRecurso.vue
@@ -222,8 +222,8 @@ export default {
       obterDadosConselho: 'conselho/obterDadosConselho',
       obterHabilitacaoRecurso: 'conselho/obterHabilitacaoRecurso',
       enviarDadosRecursoConselhoHabilitacao: 'conselho/enviarDadosRecursoConselhoHabilitacao',
-      definirMensagemSucesso: 'app/setMensagemSucesso',
-      definirMensagemErro: 'app/setMensagemErro',
+      setMensagemSucesso: 'app/setMensagemSucesso',
+      setMensagemErro: 'app/setMensagemErro',
     }),
     salvar() {
       this.loading = true;
@@ -233,7 +233,7 @@ export default {
 
       this.enviarDadosRecursoConselhoHabilitacao(dadosSubmit)
         .then((response) => {
-          this.definirMensagemSucesso(response.data.message);
+          this.setMensagemSucesso({ text: response.data.message });
           this.$router.push('/');
         }).finally(() => {
           this.loading = false;
@@ -253,7 +253,7 @@ export default {
   },
 
   beforeUpdate(){
-    this.definirMensagemErro('O prazo de envio do recurso da habilitação expirou');
+    this.setMensagemErro({ text: 'O prazo de envio do recurso da habilitação expirou'});
     this.$router.push('/');
   },
   mounted() {

--- a/webapp/src/modules/conselho/views/ConselhoIndicacao.vue
+++ b/webapp/src/modules/conselho/views/ConselhoIndicacao.vue
@@ -210,8 +210,7 @@
     </v-card>
 
     <v-layout justify-center>
-
-<v-dialog
+      <v-dialog
         v-model="dialogConfirmarConcluirIndicacao"
         max-width="360"
       >
@@ -714,7 +713,7 @@ export default {
     },
     listaIndicados: [],
     usuarioLogado: {},
-    dialogConfirmarConcluirIndicacao : false
+    dialogConfirmarConcluirIndicacao: false,
   }),
   computed: {
     ...mapGetters({
@@ -780,18 +779,18 @@ export default {
       enviarIndicacaoConselhoArquivo: 'conselho/enviarIndicacaoConselhoArquivo',
       obterListaIndicacaoConselho: 'conselho/obterListaIndicacaoConselho',
       deletarIndicacaoConselho: 'conselho/deletarIndicacaoConselho',
-      notificarErro: 'app/setMensagemErro',
-      definirMensagemSucesso: 'app/setMensagemSucesso',
+      setMensagemErro: 'app/setMensagemErro',
+      setMensagemSucesso: 'app/setMensagemSucesso',
       concluirIndicacao: 'conselho/concluirIndicacao',
     }),
     handleDialogConfirmarConcluirIndicacao() {
-        this.dialogConfirmarConcluirIndicacao = !this.dialogConfirmarConcluirIndicacao;
+      this.dialogConfirmarConcluirIndicacao = !this.dialogConfirmarConcluirIndicacao;
     },
     enviarConcluirIndicacao(coConselho) {
-        this.concluirIndicacao(coConselho).then(() => {
-            this.handleDialogConfirmarConcluirIndicacao();
-            this.loading = false;
-        })
+      this.concluirIndicacao(coConselho).then(() => {
+        this.handleDialogConfirmarConcluirIndicacao();
+        this.loading = false;
+      });
     },
     formatDate(date) {
       if (!date) return null;
@@ -809,7 +808,7 @@ export default {
       if (!Object.keys(this.indicado_foto_rosto).length || this.$refs.indicado_foto_rosto.fileHasError()) {
         this.loading = false;
         this.$refs.form.validate();
-        this.notificarErro('A foto de rosto é obrigatória.');
+        this.setMensagemErro({ text: 'A foto de rosto é obrigatória.' });
         return;
       }
 
@@ -824,7 +823,7 @@ export default {
 
       if (erro) {
         this.loading = false;
-        this.notificarErro('Preencha todos os anexos obrigatórios corretamente.');
+        this.setMensagemErro({ text: 'Preencha todos os anexos obrigatórios corretamente.' });
         return;
       }
 
@@ -857,7 +856,7 @@ export default {
         });
 
         Promise.all(promises).then(() => {
-          this.definirMensagemSucesso('Operação realizada com sucesso');
+          this.setMensagemSucesso({ text: 'Operação realizada com sucesso' });
           this.loading = false;
           window.location.reload();
           this.fecharDialogo();

--- a/webapp/src/modules/conta/store/actions.js
+++ b/webapp/src/modules/conta/store/actions.js
@@ -24,8 +24,9 @@ export const autenticarUsuario = async ({ commit, dispatch }, usuario) => {
     }).catch((error) => {
       dispatch(
         'app/setMensagemErro',
-        { text: error.response.data.error },
-        // {callbackAfterHide: () => {alert(1)}},
+        { text: error.response.data.error,
+          //callbackAfterHide: () => {alert(1)}
+          },
         { root: true },
       );
       throw new TypeError(error, 'autenticarUsuario', 10);

--- a/webapp/src/modules/conta/store/actions.js
+++ b/webapp/src/modules/conta/store/actions.js
@@ -1,4 +1,3 @@
-import { remove, includes } from 'lodash';
 import * as usuarioService from '../service/usuario';
 import * as types from './types';
 import { obterInformacoesJWT } from '../../shared/service/helpers/jwt';
@@ -16,7 +15,7 @@ export const autenticarUsuario = async ({ commit, dispatch }, usuario) => {
 
       dispatch(
         'app/setMensagemSucesso',
-        'Login efetuado com sucesso!',
+        { text: 'Login efetuado com sucesso!' },
         { root: true },
       );
       dispatch('conta/tratarUsuarioLogado', null, { root: true });
@@ -25,7 +24,8 @@ export const autenticarUsuario = async ({ commit, dispatch }, usuario) => {
     }).catch((error) => {
       dispatch(
         'app/setMensagemErro',
-        error.response.data.error,
+        { text: error.response.data.error },
+        // {callbackAfterHide: () => {alert(1)}},
         { root: true },
       );
       throw new TypeError(error, 'autenticarUsuario', 10);
@@ -55,14 +55,14 @@ export const cadastrarUsuario = async ({ commit, dispatch }, usuario) => usuario
   commit(types.ATRIBUIR_USUARIO_CADASTRADO_LISTA, data);
   dispatch(
     'app/setMensagemSucesso',
-    'Usuário cadastrado com sucesso!',
+    { text: 'Usuário cadastrado com sucesso!' },
     { root: true },
   );
   return response;
 }).catch((error) => {
   dispatch(
     'app/setMensagemErro',
-    error.response.data.message,
+    { text: error.response.data.message },
     { root: true },
   );
   throw new TypeError(error);
@@ -74,14 +74,14 @@ export const atualizarUsuario = async ({ commit, dispatch }, usuario) => usuario
 
   dispatch(
     'app/setMensagemSucesso',
-    'Usuário atualizado com sucesso.',
+    { text: 'Usuário atualizado com sucesso.' },
     { root: true },
   );
   return response;
 }).catch((error) => {
   dispatch(
     'app/setMensagemErro',
-    error.response.data.message,
+    { text: error.response.data.message },
     { root: true },
   );
   throw new TypeError(error);

--- a/webapp/src/modules/conta/views/AlteracaoDeSenha.vue
+++ b/webapp/src/modules/conta/views/AlteracaoDeSenha.vue
@@ -75,8 +75,8 @@ export default {
   methods: {
     ...mapActions({
       alterarSenha: 'conta/alterarSenha',
-      mensagemErro: 'app/setMensagemErro',
-      mensagemSucesso: 'app/setMensagemSucesso',
+      setMensagemErro: 'app/setMensagemErro',
+      setMensagemSucesso: 'app/setMensagemSucesso',
     }),
     alterar() {
       if (!this.$refs.form.validate()) {
@@ -87,11 +87,11 @@ export default {
         codigoAlteracao: this.$route.params.ds_codigo_ativacao,
         usuario: this.usuario,
       }).then(() => {
-        this.mensagemSucesso('Senha criada com sucesso');
+        this.setMensagemSucesso({ text: 'Senha criada com sucesso' });
         this.$router.push('/conta/autenticar');
       }).catch((error) => {
         this.loading = false;
-        this.mensagemErro(error.response.data.message);
+        this.setMensagemErro({ text: error.response.data.message });
       });
     },
   },

--- a/webapp/src/modules/conta/views/Cadastro.vue
+++ b/webapp/src/modules/conta/views/Cadastro.vue
@@ -4,11 +4,18 @@
       <v-window-item :value="1">
         <v-card-title>
           <div class="layout column align-center">
-            <h2 class="flex my-2 primary--text">{{$route.meta.title}}</h2>
+            <h2 class="flex my-2 primary--text">
+              {{ $route.meta.title }}
+            </h2>
           </div>
         </v-card-title>
         <v-card-text>
-          <v-form ref="form" v-model="valid" lazy-validation autocomplete="off">
+          <v-form
+            ref="form"
+            v-model="valid"
+            lazy-validation
+            autocomplete="off"
+          >
             <v-text-field
               v-model="usuario.nu_cpf"
               prepend-icon="account_circle"
@@ -48,9 +55,12 @@
                     prepend-icon="event"
                     :rules="[rules.required]"
                     v-on="on"
-                  ></v-text-field>
+                  />
                 </template>
-                <v-date-picker v-model="date" @input="menu = false"></v-date-picker>
+                <v-date-picker
+                  v-model="date"
+                  @input="menu = false"
+                />
               </v-menu>
             </template>
             <v-text-field
@@ -79,8 +89,8 @@
               :type="mostrarSenha ? 'text' : 'password'"
               label="Senha"
               name="password"
-              @click:append="mostrarSenha = !mostrarSenha"
               :rules="[rules.required, rules.minCaracter, rules.senhaValida]"
+              @click:append="mostrarSenha = !mostrarSenha"
             />
             <v-text-field
               id="confirm_password"
@@ -90,8 +100,8 @@
               :type="mostrarSenha ? 'text' : 'password'"
               label="Confirmar senha"
               name="confirm_password"
-              @click:append="mostrarSenha = !mostrarSenha"
               :rules="[rules.required, rules.confirmaSenha(usuario.confirma_senha, usuario.ds_senha)]"
+              @click:append="mostrarSenha = !mostrarSenha"
             />
           </v-form>
           <span class="grey--text">Todos os campos são obrigatórios</span>
@@ -104,24 +114,45 @@
             color="primary"
             :loading="loading"
             @click="login"
-          >Cadastrar</v-btn>
+          >
+            Cadastrar
+          </v-btn>
           <v-spacer />
-          <v-btn block color="default" :to="{ name: 'conta-autenticar' }">Voltar</v-btn>
+          <v-btn
+            block
+            color="default"
+            :to="{ name: 'conta-autenticar' }"
+          >
+            Voltar
+          </v-btn>
         </div>
         <!-- </v-card-actions> -->
       </v-window-item>
       <v-window-item :value="2">
         <v-card-text>
           <div class="text-xs-center">
-            <v-icon size="80px" color="primary">check_circle</v-icon>
-            <h3 class="title font-weight-light mb-2">Cadastro realizado com sucesso</h3>
+            <v-icon
+              size="80px"
+              color="primary"
+            >
+              check_circle
+            </v-icon>
+            <h3 class="title font-weight-light mb-2">
+              Cadastro realizado com sucesso
+            </h3>
             <span
               class="caption grey--text"
-            >Um link para ativação da sua conta foi enviado para o e-mail {{usuario.no_email}}.</span>
+            >Um link para ativação da sua conta foi enviado para o e-mail {{ usuario.no_email }}.</span>
           </div>
         </v-card-text>
         <!-- <v-card-actions> -->
-        <v-btn block color="primary" :to="{ name: 'conta-autenticar' }">Login</v-btn>
+        <v-btn
+          block
+          color="primary"
+          :to="{ name: 'conta-autenticar' }"
+        >
+          Login
+        </v-btn>
         <!-- </v-card-actions> -->
       </v-window-item>
     </v-window>
@@ -129,8 +160,8 @@
 </template>
 
 <script>
-import { mapActions } from "vuex";
-import Validate from "@/modules/shared/util/validate";
+import { mapActions } from 'vuex';
+import Validate from '@/modules/shared/util/validate';
 
 export default {
   data: () => ({
@@ -142,39 +173,36 @@ export default {
     dataFormatada: '',
     step: 1,
     usuario: {
-      no_cpf: "",
-      no_nome: "",
-      dt_nascimento: "",
-      no_email: "",
-      ds_senha: ""
+      no_cpf: '',
+      no_nome: '',
+      dt_nascimento: '',
+      no_email: '',
+      ds_senha: '',
     },
     rules: {
-      required: value => !!value || "Este campo é obrigatório",
-      validarCPF: value => Validate.isCpfValido(value) || "CPF inválido",
-      emailValido: value => Validate.isEmailValido(value) || "E-mail inválido",
-      confirmaEmail: (confirma_email, no_email) =>
-        confirma_email === no_email || "O E-mail não confere",
-      minCaracter: value => value.length >= 8 || "Mínimo 8 caracteres",
-      senhaValida: value =>
-        Validate.isSenhaValida(value) ||
-        "Mínimo uma letra maiúscula, uma minúscula e um número",
-      confirmaSenha: (confirma_senha, ds_senha) =>
-        confirma_senha === ds_senha || "A senha não confere"
-    }
+      required: value => !!value || 'Este campo é obrigatório',
+      validarCPF: value => Validate.isCpfValido(value) || 'CPF inválido',
+      emailValido: value => Validate.isEmailValido(value) || 'E-mail inválido',
+      confirmaEmail: (confirma_email, no_email) => confirma_email === no_email || 'O E-mail não confere',
+      minCaracter: value => value.length >= 8 || 'Mínimo 8 caracteres',
+      senhaValida: value => Validate.isSenhaValida(value)
+        || 'Mínimo uma letra maiúscula, uma minúscula e um número',
+      confirmaSenha: (confirma_senha, ds_senha) => confirma_senha === ds_senha || 'A senha não confere',
+    },
   }),
   watch: {
     date() {
       this.dataFormatada = this.formatDate(this.date);
-    }
+    },
   },
   methods: {
     ...mapActions({
-      cadastrarUsuario: "conta/cadastrarUsuario",
-      mensagemErro: "app/setMensagemErro"
+      cadastrarUsuario: 'conta/cadastrarUsuario',
+      setMensagemErro: 'app/setMensagemErro',
     }),
     formatDate(date) {
       if (!date) return null;
-      const [year, month, day] = date.split("-");
+      const [year, month, day] = date.split('-');
       return `${day}/${month}/${year}`;
     },
     login() {
@@ -183,7 +211,7 @@ export default {
       }
       this.loading = true;
 
-      const [dia, mes, ano] = this.dataFormatada.split("/");
+      const [dia, mes, ano] = this.dataFormatada.split('/');
       this.usuario.dt_nascimento = `${ano}-${mes}-${dia}`;
 
       this.cadastrarUsuario(this.usuario)
@@ -191,11 +219,11 @@ export default {
           this.loading = false;
           this.step = 2;
         })
-        .catch(error => {
+        .catch((error) => {
           this.loading = false;
-          this.mensagemErro(error.response.data.message);
+          this.setMensagemErro({ text: error.response.data.message });
         });
-    }
-  }
+    },
+  },
 };
 </script>

--- a/webapp/src/modules/conta/views/PrimeiroAcesso.vue
+++ b/webapp/src/modules/conta/views/PrimeiroAcesso.vue
@@ -182,7 +182,7 @@ export default {
   methods: {
     ...mapActions({
       solicitarPrimeiroAcesso: 'conta/solicitarPrimeiroAcesso',
-      mensagemErro: 'app/setMensagemErro',
+      setMensagemErro: 'app/setMensagemErro',
     }),
     solicitarAcesso() {
       this.loading = true;
@@ -193,7 +193,7 @@ export default {
         })
         .catch((error) => {
           this.loading = false;
-          this.mensagemErro(error.response.data.message);
+          this.setMensagemErro({ text: error.response.data.message });
         });
     },
   },

--- a/webapp/src/modules/conta/views/RecuperacaoDeSenha.vue
+++ b/webapp/src/modules/conta/views/RecuperacaoDeSenha.vue
@@ -124,7 +124,7 @@ export default {
   methods: {
     ...mapActions({
       recuperarSenha: 'conta/recuperarSenha',
-      mensagemErro: 'app/setMensagemErro',
+      setMensagemErro: 'app/setMensagemErro',
     }),
     recuperar() {
       if (!this.$refs.form.validate()) {
@@ -137,7 +137,7 @@ export default {
           this.step = 2;
         })
         .catch((error) => {
-          this.mensagemErro(error.response.data.message);
+          this.setMensagemErro({ text: error.response.data.message });
         }).finally(() => {
           this.loading = false;
         });

--- a/webapp/src/modules/conta/views/usuario/AlteracaoDeSenha.vue
+++ b/webapp/src/modules/conta/views/usuario/AlteracaoDeSenha.vue
@@ -136,8 +136,8 @@ export default {
   methods: {
     ...mapActions({
       alterarSenha: 'conta/usuarioAlterarSenha',
-      mensagemErro: 'app/setMensagemErro',
-      mensagemSucesso: 'app/setMensagemSucesso',
+      setMensagemErro: 'app/setMensagemErro',
+      setMensagemSucesso: 'app/setMensagemSucesso',
     }),
     alterar() {
       if (!this.$refs.form.validate()) {
@@ -154,12 +154,12 @@ export default {
         },
       )
         .then(() => {
-          this.mensagemSucesso('Senha alterada com sucesso');
+          this.setMensagemSucesso({ text: 'Senha alterada com sucesso' });
           this.$router.push('/conta/sair');
         })
         .catch((error) => {
           this.loading = false;
-          this.mensagemErro(error.response.data.message);
+          this.setMensagemErro({ text: error.response.data.message });
         });
     },
   },

--- a/webapp/src/modules/eleitor/store/actions.js
+++ b/webapp/src/modules/eleitor/store/actions.js
@@ -29,7 +29,7 @@ export const obterDadosEleitor = async ({ commit, dispatch }, coEleitor) => {
     .catch((error) => {
       dispatch(
         'app/setMensagemErro',
-        error.response.data.error,
+        { text: error.response.data.error },
         { root: true },
       );
       throw new TypeError(error, 'obterDadosEleitor', 10);

--- a/webapp/src/modules/organizacao/store/actions.js
+++ b/webapp/src/modules/organizacao/store/actions.js
@@ -38,7 +38,7 @@ export const obterDadosOrganizacao = async ({ commit, dispatch }, coOrganizacao)
     .catch((error) => {
       dispatch(
         'app/setMensagemErro',
-        error.response.data.error,
+        { text: error.response.data.error },
         { root: true },
       );
       throw new TypeError(error, 'obterDadosOrganizacao', 10);
@@ -91,7 +91,7 @@ export const obterOrganizacoesHabilitacao = async ({ commit }) => {
 export const avaliarHabilitacao = async ({ dispatch }, organizacaoHabilitacao) => organizacaoService.avaliarHabilitacao(organizacaoHabilitacao).then(response => response).catch((error) => {
   dispatch(
     'app/setMensagemErro',
-    error.response.data.message,
+    { text: error.response.data.message },
     { root: true },
   );
   throw new TypeError(error);

--- a/webapp/src/modules/organizacao/views/Organizacao.vue
+++ b/webapp/src/modules/organizacao/views/Organizacao.vue
@@ -810,7 +810,7 @@ export default {
       const faseOrganizacao = data.find(fase => fase.tp_fase === faseSlug);
 
       if ((!faseOrganizacao || Object.keys(faseOrganizacao).length === 0) && self.perfil.no_perfil !== 'administrador') {
-        self.mensagemErro('O prazo de inscrições expirou!');
+        self.setMensagemErro({ text: 'O prazo de inscrições expirou!'});
         self.$router.push('/');
       }
       self.dataDentroPrazoInscricao = true;
@@ -837,7 +837,7 @@ export default {
   methods: {
     ...mapActions({
       validarDataDentroPrazoFasePorSlug: 'fase/validarDataDentroPrazoFasePorSlug',
-      mensagemErro: 'app/setMensagemErro',
+      setMensagemErro: 'app/setMensagemErro',
       obterEstados: 'localidade/obterEstados',
       obterMunicipios: 'localidade/obterMunicipios',
       obterCriterios: 'organizacao/obterCriterios',

--- a/webapp/src/modules/organizacao/views/OrganizacaoDocumentacaoComprobatoria.vue
+++ b/webapp/src/modules/organizacao/views/OrganizacaoDocumentacaoComprobatoria.vue
@@ -363,8 +363,8 @@ export default {
   },
   methods: {
     ...mapActions({
-      notificarErro: 'app/setMensagemErro',
-      notificarSucesso: 'app/setMensagemSucesso',
+      setMensagemErro: 'app/setMensagemErro',
+      setMensagemSucesso: 'app/setMensagemSucesso',
       enviarDocumentacaoComprobatoria: 'organizacao/enviarDocumentacaoComprobatoria',
       obterDocumentacaoComprobatoria: 'organizacao/obterDocumentacaoComprobatoria',
     }),
@@ -411,17 +411,17 @@ export default {
       });
 
       if (!this.valid_anexo) {
-        this.notificarErro('Anexe os documentos obrigatórios!');
+        this.setMensagemErro({ text: 'Anexe os documentos obrigatórios!' });
         this.loading = false;
         return false;
       }
 
       this.enviarDocumentacaoComprobatoria(this.organizacao).then((response) => {
         const { data } = response;
-        self.notificarSucesso(data.message);
+        self.setMensagemSucesso({ text: data.message });
         window.location.reload();
       }).catch((error) => {
-        self.notificarErro(error);
+        self.setMensagemErro({ text: error });
         this.loading = false;
       });
       return true;
@@ -429,13 +429,13 @@ export default {
   },
   mounted() {
     // if (!this.usuarioGetter) {
-    //   this.notificarErro('É necessário autenticação');
+    //   this.setMensagemErro({ text: 'É necessário autenticação' });
     //   this.$router.push('/conta/autenticar');
     // }
     this.$router.push('/');
-    this.notificarErro('Prazo para envio da documentação expirou.');
+    this.setMensagemErro({ text: 'Prazo para envio da documentação expirou.' });
     if (this.usuarioGetter.co_organizacao === null) {
-      this.notificarErro('Acesso restrito para organização e entidades culturais.');
+      this.setMensagemErro({ text: 'Acesso restrito para organização e entidades culturais.' });
       this.$router.push('/');
     }
 

--- a/webapp/src/modules/recurso/store/actions.js
+++ b/webapp/src/modules/recurso/store/actions.js
@@ -15,7 +15,7 @@ export const enviarDadosRecursoInscricao = async ({ commit, dispatch }, recurso)
   return recursoService.enviarDadosRecursoInscricao(recurso).catch((error) => {
     dispatch(
       'app/setMensagemErro',
-      error.response.data.message,
+      { text: error.response.data.message },
       { root: true },
     );
     throw new TypeError(error, 'enviarDadosRecursoInscricao', 10);
@@ -37,7 +37,7 @@ export const obterDadosRecurso = async ({ commit, dispatch }, coRecurso) => {
     .catch((error) => {
       dispatch(
         'app/setMensagemErro',
-        error.response.data.error,
+        { text: error.response.data.error },
         { root: true },
       );
       throw new TypeError(error, 'obterDadosRecurso', 10);
@@ -57,14 +57,14 @@ export const avaliarRecursoInscricao = async ({ commit, dispatch }, recurso) => 
 
   dispatch(
     'app/setMensagemSucesso',
-    'Recurso avaliado com sucesso!',
+    { text: 'Recurso avaliado com sucesso!' },
     { root: true },
   );
   return response;
 }).catch((error) => {
   dispatch(
     'app/setMensagemErro',
-    error.response.data.message,
+    { text: error.response.data.message },
     { root: true },
   );
   throw new TypeError(error);

--- a/webapp/src/modules/recurso/views/RecursoInscricao.vue
+++ b/webapp/src/modules/recurso/views/RecursoInscricao.vue
@@ -325,8 +325,8 @@ export default {
     ...mapActions({
       consultarCNPJ: 'pessoa/consultarCNPJ',
       consultarCPF: 'pessoa/consultarCPF',
-      definirMensagemSucesso: 'app/setMensagemSucesso',
-      definirMensagemErro: 'app/setMensagemErro',
+      setMensagemSucesso: 'app/setMensagemSucesso',
+      setMensagemErro: 'app/setMensagemErro',
       enviarDadosRecursoInscricao: 'recurso/enviarDadosRecursoInscricao',
     }),
     validarIrProximaEtapa(formRef) {
@@ -341,7 +341,7 @@ export default {
 
       this.enviarDadosRecursoInscricao(this.recursoInscricao)
         .then((response) => {
-          this.definirMensagemSucesso(response.data.message);
+          this.setMensagemSucesso({ text: response.data.message });
           this.$router.push('/');
         }).finally(() => {
           this.loading = false;
@@ -360,7 +360,7 @@ export default {
     },
   },
   mounted() {
-    this.definirMensagemErro('O prazo de recurso expirou!');
+    this.setMensagemErro({ text: 'O prazo de recurso expirou!' });
     this.$router.push('/');
   },
 };

--- a/webapp/src/modules/representante/store/actions.js
+++ b/webapp/src/modules/representante/store/actions.js
@@ -25,7 +25,7 @@ export const obterDadosRepresentante = async ({ commit, dispatch }, coRepresenta
     .catch((error) => {
       dispatch(
         'app/setMensagemErro',
-        error.response.data.error,
+        { text: error.response.data.error },
         { root: true },
       );
       throw new TypeError(error, 'obterDadosRepresentante', 10);

--- a/webapp/src/router.js
+++ b/webapp/src/router.js
@@ -37,7 +37,7 @@ router.beforeEach((to, from, next) => {
 
     next(proximaPagina);
   }).catch((Exception) => {
-    store.dispatch('app/setMensagemErro', `Erro: ${Exception}`, { root: true });
+    store.dispatch('app/setMensagemErro', { text: `Erro: ${Exception}` }, { root: true });
     return next('/conta/autenticar');
   });
 });


### PR DESCRIPTION
Galera acabei de fazer uma abordagem mto bacana para as chamadas de de mensagens permitindo callback
Refatorei todas as chamadas do projeto para mensagens de sucesso, erro e informação
agora todas as actions, ao invés de receber uma string, recebem um objeto
Dessa forma, agora é possível informar a propriedade : callbackAfterHide
Ela sempre será acionada quando o SnackBar( barrinha de mensagem ) for fechada automaticamente ou ao clicar no botão de fechar dela
aqui um exemplo de como utilizar:
dispatch(
        'app/setMensagemSucesso',
        { text: 'Minha mensagem',
          callbackAfterHide: () => { alert('bye bye') }
          },
        { root: true },
      );
Enviei um pull request para a branch develop com essa nova definição
Vai ajudar vocês naqueles locais que querem dar ações após exibir a mensagem